### PR TITLE
Revert "fix ci job system to deploy to gai-platform namespace"

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -134,7 +134,7 @@ workflows:
           env: ""
           region: tokyo
           cluster: common-0
-          system: gai-platform
+          system: realtime-streaming
           target: postgres
           skaffold_use_cluster_profile: true
           requires:
@@ -151,7 +151,7 @@ workflows:
           env: ""
           region: tokyo
           cluster: common-0
-          system: gai-platform
+          system: realtime-streaming
           target: clickhouse
           skaffold_use_cluster_profile: true
           requires:
@@ -168,7 +168,7 @@ workflows:
           env: ""
           region: tokyo
           cluster: common-0
-          system: gai-platform
+          system: realtime-streaming
           target: supertokens
           skaffold_use_cluster_profile: true
           requires:
@@ -185,7 +185,7 @@ workflows:
           env: ""
           region: tokyo
           cluster: common-0
-          system: gai-platform
+          system: realtime-streaming
           target: redis
 #          resourceClass: large
           skaffold_use_cluster_profile: true


### PR DESCRIPTION
Reverts smartnews/dp-LLM-ops#397